### PR TITLE
Changed to allow version info to be retrieved from appropriate calling assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- [DesktopAnalytics] Changed useExecutingAssembly flag in one of the Analytics constructors to useCallingAssemblyVersion
+- [DesktopAnalytics] Changed useExecutingAssembly flag in the other Analytics constructor to assemblyToUseForVersion
+
 ## [5.1.0] - 2024-03-16
 
 ### Changed


### PR DESCRIPTION
This fixes the previous errant attempt to support plugins. Rather than a flag tp use the currently executing assembly (which will always be the DesktopAnalytics DLL itself and which is **never** what we want), the caller can either pass a flag or an actual assembly to be used for retrieving the version information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/DesktopAnalytics.net/37)
<!-- Reviewable:end -->
